### PR TITLE
fix Entra ID logout URL

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -546,7 +546,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         window.location.href = `${issuer}/v1/logout?${params.toString()}`;
       } else if (currentConfig.provider_type === "entra_id") {
         const params = new URLSearchParams({ post_logout_redirect_uri: returnUrl });
-        window.location.href = `${issuer}/oauth2/v2.0/logout?${params.toString()}`;
+        const authority = issuer.replace(/\/v2\.0$/i, "");
+        window.location.href = `${authority}/oauth2/v2.0/logout?${params.toString()}`;
       }
     }
   }, [tokens, logout]);


### PR DESCRIPTION
Entra ID issuers are configured with a trailing /v2.0 path. Appending the logout route directly produced /v2.0/oauth2/v2.0/logout, which is not a valid Microsoft identity platform endpoint and prevented users from fully signing out or switching accounts.

Remove the trailing /v2.0 segment before constructing the Entra logout URL. Issuers without that suffix and the existing Okta logout flow remain unchanged.

Validated with the frontend TypeScript check, production build, and representative Entra issuer URL cases.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
