### PR TITLE
fix: support corporate TLS proxy via OS trust store for JWKS fetch

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,14 @@ import os
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
+# Delegate TLS verification to the OS trust store when enabled (e.g. behind a
+# corporate TLS-intercepting proxy such as Zscaler, whose root CA OpenSSL 3.x
+# rejects). Must run before any module creates an SSL context.
+if os.getenv("LOOM_USE_SYSTEM_TRUST_STORE", "").lower() in ("1", "true", "yes"):
+    import truststore
+
+    truststore.inject_into_ssl()
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ python-multipart>=0.0.9
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
 httpx>=0.26.0
+truststore>=0.10.0


### PR DESCRIPTION
## Problem

Behind a TLS-intercepting corporate proxy (e.g. Zscaler), the backend fails to fetch the Cognito JWKS with:

```
SSL: CERTIFICATE_VERIFY_FAILED: Basic Constraints of CA cert not marked critical
```

The proxy's root CA has `basicConstraints: ca=True critical=False`, which violates RFC 5280. OpenSSL 3.x (Python 3.12+) enforces this strictly and rejects the cert during path building. The browser works because macOS's Security framework is lenient about this legacy quirk, but the backend's `urllib`-based JWKS fetch in `jwt_validator.py` uses OpenSSL and fails. Every authenticated API call then returns 401.

Note: `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` cannot fix this — the problem is a *non-compliant* CA being rejected, not a *missing* one.

## Fix

Add an opt-in dependency on `truststore`, which delegates TLS verification to the OS trust store (same path the browser/curl use). Injected at startup in `app/main.py` before any SSL context is created, and gated behind `LOOM_USE_SYSTEM_TRUST_STORE` so it's disabled by default — CI/production keep standard OpenSSL verification.

## Changes

- `backend/requirements.txt`: add `truststore>=0.10.0`
- `backend/app/main.py`: inject `truststore` at startup when `LOOM_USE_SYSTEM_TRUST_STORE` is truthy

## Verification

- Reproduced the failure; confirmed `SSL_CERT_FILE` with the proxy root added does **not** resolve it.
- With the flag enabled, the app's `_get_jwks()` fetches the Cognito JWKS successfully (HTTP 200).
- App imports cleanly with the flag off; `test_auth.py` passes (7 passed).

To enable locally: `export LOOM_USE_SYSTEM_TRUST_STORE=true`