### PR TITLE
Preserve harness provider config and authenticate API-key MCP tools

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -2512,6 +2512,10 @@ def _update_harness_background(
     vpc_subnet_ids: list[str] | None = None,
     vpc_security_group_ids: list[str] | None = None,
     ci_config: dict[str, Any] | None = None,
+    provider: str = "bedrock",
+    base_url: str | None = None,
+    litellm_cp_name: str | None = None,
+    litellm_cp_arn: str | None = None,
 ) -> None:
     """Background task that updates an existing harness via UpdateHarness API."""
     db = SessionLocal()
@@ -2666,6 +2670,10 @@ def _update_harness_background(
             "system_prompt": system_prompt,
             "model_id": model_id,
             "max_tokens": max_tokens,
+            "provider": provider,
+            "base_url": base_url or "",
+            "litellm_api_key_credential_provider_name": litellm_cp_name or "",
+            "litellm_api_key_credential_provider_arn": litellm_cp_arn or "",
             "harness_config": {
                 "tools": all_mcp_tools,
                 "deploy_tools": harness_tools,
@@ -2704,6 +2712,9 @@ def _update_harness_background(
             memory_arn=primary_memory_arn,
             memory_retrieval_config=primary_memory_retrieval_config,
             region=region,
+            provider=provider,
+            litellm_api_key_arn=litellm_cp_arn,
+            litellm_api_base=base_url,
         )
 
         harness_status = response.get("status", "UPDATING")
@@ -3617,17 +3628,18 @@ def redeploy_harness_agent(
         )
 
     region = os.getenv("AWS_REGION", DEFAULT_REGION)
-    account_id = os.getenv("AWS_ACCOUNT_ID", "")
+    account_id = os.getenv("AWS_ACCOUNT_ID", "") or agent.account_id
 
     # Clean up old credential providers that are no longer needed
     old_config_entry = db.query(ConfigEntry).filter(
         ConfigEntry.agent_id == agent_id, ConfigEntry.key == "AGENT_CONFIG_JSON"
     ).first()
     old_cp_names: set[str] = set()
+    old_agent_config: dict[str, Any] = {}
     if old_config_entry:
         try:
-            old_config = json.loads(old_config_entry.value)
-            old_mcp = old_config.get("integrations", {}).get("mcp_servers", [])
+            old_agent_config = json.loads(old_config_entry.value)
+            old_mcp = old_agent_config.get("integrations", {}).get("mcp_servers", [])
             for srv in old_mcp:
                 cp_name = (srv.get("auth", {}) or {}).get("credential_provider_name")
                 if cp_name:
@@ -3640,6 +3652,32 @@ def redeploy_harness_agent(
     # Update agent fields
     resolved_tags, _ = _resolve_tags(db, request.tags)
     system_prompt = _build_system_prompt(request)
+
+    provider = request.provider
+    litellm_base_url: str | None = None
+    litellm_cp_name: str | None = None
+    litellm_cp_arn: str | None = None
+    if provider == "litellm":
+        from app.services.litellm import get_agent_base_url
+
+        litellm_base_url = (
+            get_agent_base_url(db)
+            or request.base_url
+            or old_agent_config.get("base_url")
+        )
+        sanitized_name = re.sub(r"[^a-zA-Z0-9-.]", "-", agent.name)
+        litellm_cp_name = (
+            old_agent_config.get("litellm_api_key_credential_provider_name")
+            or f"loom-{sanitized_name}-litellm-key"
+        )
+        litellm_cp_arn = old_agent_config.get(
+            "litellm_api_key_credential_provider_arn"
+        )
+        if not litellm_cp_arn and account_id:
+            litellm_cp_arn = (
+                f"arn:aws:bedrock-agentcore:{region}:{account_id}:"
+                f"token-vault/default/apikeycredentialprovider/{litellm_cp_name}"
+            )
 
     agent.description = request.description or agent.description
     agent.execution_role_arn = request.role_arn or agent.execution_role_arn
@@ -3776,6 +3814,10 @@ def redeploy_harness_agent(
         region=region,
         account_id=account_id,
         ci_config=update_ci_config,
+        provider=provider,
+        base_url=litellm_base_url,
+        litellm_cp_name=litellm_cp_name,
+        litellm_cp_arn=litellm_cp_arn,
     )
 
     return _agent_response(agent, db)

--- a/backend/app/routers/invocations.py
+++ b/backend/app/routers/invocations.py
@@ -1066,10 +1066,30 @@ async def invoke_harness_agent_stream(
     if dynamic_tools:
         if invoke_tools is None:
             invoke_tools = []
-        existing_names = {t.get("name") for t in invoke_tools}
+        existing_by_name = {
+            tool.get("name"): tool
+            for tool in invoke_tools
+            if tool.get("name")
+        }
         for tool in dynamic_tools:
-            if tool.get("name") not in existing_names:
+            existing = existing_by_name.get(tool.get("name"))
+            if existing is None:
                 invoke_tools.append(_json.loads(_json.dumps(tool)))
+                continue
+
+            # The deployed harness stores only the connector URL. Invocation
+            # data carries user-scoped credentials; merge those headers into
+            # the configured tool instead of dropping the duplicate by name.
+            dynamic_remote = (tool.get("config") or {}).get("remoteMcp") or {}
+            dynamic_headers = dynamic_remote.get("headers") or {}
+            if dynamic_headers:
+                existing_remote = (
+                    existing.setdefault("config", {})
+                    .setdefault("remoteMcp", {})
+                )
+                existing_headers = existing_remote.get("headers") or {}
+                existing_headers.update(dynamic_headers)
+                existing_remote["headers"] = existing_headers
 
     invocation.client_invoke_time = client_invoke_time
     invocation.status = "streaming"
@@ -1586,7 +1606,10 @@ async def invoke_agent_endpoint(
                 "endpoint_url": server.endpoint_url,
             }
             if server.auth_type == "api_key":
-                secret_name = f"loom/mcp/{server.name}/api-key/{actor_id}"
+                # Per-user keys are stored by the immutable IdP subject.  The
+                # actor_id is a separately formatted value used by AgentCore
+                # sessions and does not identify the Secrets Manager entry.
+                secret_name = f"loom/mcp/{server.name}/api-key/{user.sub}"
                 entry["auth"] = {
                     "type": "api_key",
                     "credentials_secret_arn": secret_name,
@@ -1667,10 +1690,31 @@ async def invoke_agent_endpoint(
         if dynamic_mcp_servers:
             dynamic_harness_tools = []
             for mcp in dynamic_mcp_servers:
+                remote_mcp: dict[str, Any] = {"url": mcp["endpoint_url"]}
+                auth = mcp.get("auth") or {}
+                if auth.get("type") == "api_key":
+                    try:
+                        api_key = get_secret(
+                            auth["credentials_secret_arn"],
+                            agent.region,
+                        )
+                        header_name = auth.get("api_key_header_name") or "x-api-key"
+                        header_value = (
+                            f"Bearer {api_key}"
+                            if header_name.lower() == "authorization"
+                            else api_key
+                        )
+                        remote_mcp["headers"] = {header_name: header_value}
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to resolve the user API key for MCP connector '%s': %s",
+                            mcp["name"],
+                            exc,
+                        )
                 tool_entry: dict[str, Any] = {
                     "type": "remote_mcp",
                     "name": mcp["name"],
-                    "config": {"remoteMcp": {"url": mcp["endpoint_url"]}},
+                    "config": {"remoteMcp": remote_mcp},
                 }
                 dynamic_harness_tools.append(tool_entry)
 

--- a/backend/tests/test_harness.py
+++ b/backend/tests/test_harness.py
@@ -648,7 +648,7 @@ class TestDeployHarnessLitellmProvider(unittest.TestCase):
         mock_agent_base_url.return_value = "https://my-proxy.example.com"
         mock_vend.return_value = "sk-virtual-key"
         mock_create_cp.return_value = {
-            "credentialProviderArn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default/apikeycredentialprovider/loom-litellm_harness-litellm-key",
+            "credentialProviderArn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default/apikeycredentialprovider/loom-litellm-harness-litellm-key",
         }
         mock_create_harness.return_value = {
             "harnessId": "h-litellm-e2e",
@@ -672,14 +672,14 @@ class TestDeployHarnessLitellmProvider(unittest.TestCase):
 
         mock_vend.assert_called_once()
         mock_create_cp.assert_called_once()
-        self.assertEqual(mock_create_cp.call_args[1]["name"], "loom-litellm_harness-litellm-key")
+        self.assertEqual(mock_create_cp.call_args[1]["name"], "loom-litellm-harness-litellm-key")
         self.assertEqual(mock_create_cp.call_args[1]["api_key"], "sk-virtual-key")
 
         create_kwargs = mock_create_harness.call_args[1]
         self.assertEqual(create_kwargs["provider"], "litellm")
         self.assertEqual(
             create_kwargs["litellm_api_key_arn"],
-            "arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default/apikeycredentialprovider/loom-litellm_harness-litellm-key",
+            "arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default/apikeycredentialprovider/loom-litellm-harness-litellm-key",
         )
         self.assertEqual(create_kwargs["litellm_api_base"], "https://my-proxy.example.com")
 
@@ -691,7 +691,108 @@ class TestDeployHarnessLitellmProvider(unittest.TestCase):
         config_data = json.loads(config.value)
         self.assertEqual(config_data["provider"], "litellm")
         self.assertEqual(config_data["base_url"], "https://my-proxy.example.com")
-        self.assertEqual(config_data["litellm_api_key_credential_provider_name"], "loom-litellm_harness-litellm-key")
+        self.assertEqual(config_data["litellm_api_key_credential_provider_name"], "loom-litellm-harness-litellm-key")
+
+    @patch("app.routers.agents.update_harness_api")
+    @patch("app.routers.agents.create_harness_api")
+    @patch("app.routers.agents.create_api_key_credential_provider")
+    @patch("app.services.litellm.vend_virtual_key")
+    @patch("app.services.litellm.get_agent_base_url")
+    def test_redeploy_harness_preserves_litellm_provider(
+        self,
+        mock_agent_base_url,
+        mock_vend,
+        mock_create_cp,
+        mock_create_harness,
+        mock_update_harness,
+    ):
+        mock_agent_base_url.return_value = "https://my-proxy.example.com"
+        mock_vend.return_value = "sk-virtual-key"
+        mock_create_cp.return_value = {
+            "credentialProviderArn": (
+                "arn:aws:bedrock-agentcore:us-east-1:123456789012:"
+                "token-vault/default/apikeycredentialprovider/"
+                "loom-litellm-harness-update-litellm-key"
+            ),
+        }
+        mock_create_harness.return_value = {
+            "harnessId": "h-litellm-update",
+            "harnessArn": (
+                "arn:aws:bedrock-agentcore:us-east-1:123456789012:"
+                "harness/h-litellm-update"
+            ),
+            "status": "READY",
+            "environment": {"agentCoreRuntimeEnvironment": {}},
+        }
+        mock_update_harness.return_value = {"status": "UPDATING"}
+
+        create_response = self.client.post(
+            "/api/agents",
+            json={
+                "source": "harness",
+                "name": "litellm_harness_update",
+                "model_id": "azure/gpt-4.1-mini",
+                "allowed_model_ids": ["azure/gpt-4.1-mini"],
+                "role_arn": "arn:aws:iam::123456789012:role/test-role",
+                "provider": "litellm",
+            },
+        )
+        self.assertEqual(create_response.status_code, 201)
+        agent_id = create_response.json()["id"]
+
+        # Simulate a legacy redeploy that dropped the LiteLLM credential
+        # metadata. The repair must reconstruct it from the agent's account.
+        agent = self.session.query(Agent).filter(Agent.id == agent_id).first()
+        agent.account_id = "123456789012"
+        existing_config = self.session.query(ConfigEntry).filter(
+            ConfigEntry.agent_id == agent_id,
+            ConfigEntry.key == "AGENT_CONFIG_JSON",
+        ).first()
+        existing_config_data = json.loads(existing_config.value)
+        existing_config_data.pop("litellm_api_key_credential_provider_name")
+        existing_config_data.pop("litellm_api_key_credential_provider_arn")
+        existing_config.value = json.dumps(existing_config_data)
+        self.session.commit()
+
+        update_response = self.client.put(
+            f"/api/agents/{agent_id}/redeploy-harness",
+            json={
+                "source": "harness",
+                "name": "litellm_harness_update",
+                "model_id": "azure/gpt-4.1-mini",
+                "allowed_model_ids": ["azure/gpt-4.1-mini"],
+                "role_arn": "arn:aws:iam::123456789012:role/test-role",
+                "provider": "litellm",
+            },
+        )
+        self.assertEqual(update_response.status_code, 200)
+
+        update_kwargs = mock_update_harness.call_args[1]
+        self.assertEqual(update_kwargs["provider"], "litellm")
+        self.assertEqual(
+            update_kwargs["litellm_api_key_arn"],
+            (
+                "arn:aws:bedrock-agentcore:us-east-1:123456789012:"
+                "token-vault/default/apikeycredentialprovider/"
+                "loom-litellm-harness-update-litellm-key"
+            ),
+        )
+        self.assertEqual(
+            update_kwargs["litellm_api_base"],
+            "https://my-proxy.example.com",
+        )
+
+        config = self.session.query(ConfigEntry).filter(
+            ConfigEntry.agent_id == agent_id,
+            ConfigEntry.key == "AGENT_CONFIG_JSON",
+        ).first()
+        config_data = json.loads(config.value)
+        self.assertEqual(config_data["provider"], "litellm")
+        self.assertEqual(config_data["base_url"], "https://my-proxy.example.com")
+        self.assertEqual(
+            config_data["litellm_api_key_credential_provider_name"],
+            "loom-litellm-harness-update-litellm-key",
+        )
 
     @patch("app.services.litellm.get_agent_base_url", return_value="")
     def test_deploy_harness_litellm_requires_configured_connection(self, mock_agent_base_url):

--- a/backend/tests/test_invocations.py
+++ b/backend/tests/test_invocations.py
@@ -1,4 +1,5 @@
 """Tests for agent invocation endpoints."""
+import json
 import time
 import unittest
 from datetime import datetime, timedelta
@@ -11,6 +12,8 @@ from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.db import Base, get_db
 from app.models.agent import Agent
+from app.models.config_entry import ConfigEntry
+from app.models.mcp import McpServer
 from app.models.session import InvocationSession
 from app.models.invocation import Invocation
 
@@ -116,6 +119,85 @@ class TestInvocationsRouter(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 404)
+
+    @patch("app.routers.invocations.get_secret", return_value="updated-user-key")
+    @patch("app.routers.invocations.get_log_events", return_value=[])
+    @patch("app.routers.invocations.parse_agent_start_time", return_value=None)
+    @patch("app.routers.invocations.compute_cold_start")
+    @patch("app.routers.invocations.derive_log_group")
+    @patch("app.routers.invocations.invoke_harness_stream")
+    @patch("app.routers.invocations.compute_client_duration", return_value=100.0)
+    def test_harness_api_key_connector_injects_user_authorization_header(
+        self,
+        _mock_duration,
+        mock_invoke_harness,
+        _mock_derive_log_group,
+        _mock_compute_cold_start,
+        _mock_parse_agent_start,
+        _mock_get_log_events,
+        mock_get_secret,
+    ):
+        """Harness tools must receive the selected user's API key at invoke time."""
+        self.agent.source = "harness"
+        self.agent.harness_id = "h-test"
+        self.agent.arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/h-test"
+
+        server = McpServer(
+            name="secured_mcp",
+            endpoint_url="https://mcp.example.com/mcp",
+            transport_type="streamable_http",
+            status="active",
+            auth_type="api_key",
+            api_key_header_name="Authorization",
+            delegation_mode="m2m",
+        )
+        self.session.add(server)
+        self.session.flush()
+        self.session.add(ConfigEntry(
+            agent_id=self.agent.id,
+            key="AGENT_CONFIG_JSON",
+            value=json.dumps({
+                "model_id": "azure/gpt-4.1-mini",
+                "provider": "litellm",
+                "harness_config": {
+                    "tools": [{
+                        "type": "remote_mcp",
+                        "name": "secured_mcp",
+                        "config": {"remoteMcp": {"url": server.endpoint_url}},
+                    }],
+                },
+                "integrations": {
+                    "mcp_servers": [{
+                        "name": "secured_mcp",
+                        "endpoint_url": server.endpoint_url,
+                        "auth_type": "api_key",
+                    }],
+                },
+            }),
+            source="env_var",
+        ))
+        self.session.commit()
+        mock_invoke_harness.return_value = iter([{"type": "text", "content": "ok"}])
+
+        response = self.client.post(
+            f"/api/agents/{self.agent.id}/invoke",
+            json={
+                "prompt": "list accessible resources",
+                "qualifier": "DEFAULT",
+                "connector_ids": [server.id],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_get_secret.assert_called_once_with(
+            "loom/mcp/secured_mcp/api-key/local",
+            "us-east-1",
+        )
+        tools = mock_invoke_harness.call_args.kwargs["tools"]
+        self.assertEqual(
+            tools[0]["config"]["remoteMcp"]["headers"]["Authorization"],
+            "Bearer updated-user-key",
+        )
 
     def test_invoke_agent_invalid_qualifier(self):
         """Test invoking with an invalid qualifier."""

--- a/frontend/src/components/InvokePanel.tsx
+++ b/frontend/src/components/InvokePanel.tsx
@@ -383,7 +383,9 @@ export function InvokePanel({ agentId, qualifiers, sessions, isStreaming, modelI
     const runtimeModelId = selectedModel && selectedModel !== modelId ? selectedModel : undefined;
     const invokeOnlyIds = [...enabledConnectors].filter((id) => {
       const c = connectors.find((cn) => cn.id === id);
-      return c && !mcpNames.includes(c.name);
+      // Deploy-time API-key tools still need the current user's key injected
+      // into each harness invocation.
+      return c && (!mcpNames.includes(c.name) || c.auth_type === "api_key");
     });
     const activeConnectorIds = invokeOnlyIds.length > 0 ? invokeOnlyIds : undefined;
     const useLinkedToken = selectedCredential === LINKED_TOKEN ? true : undefined;

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -600,7 +600,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
       const deployNames = agent?.mcp_names ?? [];
       const invokeOnlyIds = Array.from(enabledConnectors).filter((id) => {
         const c = connectors.find((cn) => cn.id === id);
-        return c && !deployNames.includes(c.name);
+        return c && (!deployNames.includes(c.name) || c.auth_type === "api_key");
       });
       const activeConnectorIds = invokeOnlyIds.length > 0 ? invokeOnlyIds : undefined;
       invoke(prompt, "DEFAULT", currentSessionId ?? undefined, undefined, undefined, rtModel, activeConnectorIds, linkStatus === "linked" ? true : undefined);
@@ -629,7 +629,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
     const deployNames = selectedAgent?.mcp_names ?? [];
     const invokeOnlyIds = Array.from(enabledConnectors).filter((id) => {
       const c = connectors.find((cn) => cn.id === id);
-      return c && !deployNames.includes(c.name);
+      return c && (!deployNames.includes(c.name) || c.auth_type === "api_key");
     });
     const activeConnectorIds = invokeOnlyIds.length > 0 ? invokeOnlyIds : undefined;
     await invoke(prompt, "DEFAULT", currentSessionId ?? undefined, undefined, undefined, runtimeModelId, activeConnectorIds, linkStatus === "linked" ? true : undefined);


### PR DESCRIPTION
## Issue

Harness configuration updates could lose the selected non-default model provider, API base URL, and credential-provider metadata. This caused subsequent updates to fall back to the default provider path.

API-key MCP tools also failed during harness invocation in several related cases:

- per-user secrets were resolved with the formatted runtime actor identifier instead of the immutable identity subject used when the secret was stored;
- built-in API-key connectors were omitted from the frontend invocation payload;
- invocation-time authentication headers were discarded when a matching tool already existed in the harness configuration.

Together, these issues could make an otherwise valid harness update unusable and cause authenticated remote MCP tools to fail initialization.

## Fix

- Preserve provider, API base URL, and credential-provider metadata across harness configuration updates.
- Reconstruct missing credential-provider metadata for older stored configurations.
- Resolve per-user API keys with the immutable identity subject.
- Inject API-key headers only for the current invocation and merge them into matching configured tools.
- Include enabled built-in API-key connectors in invocation requests.
- Add regression coverage for provider preservation and authenticated harness MCP invocation.
- Align credential-provider test fixtures with the AWS-safe normalized name.

## Impact

Harness updates retain their selected provider configuration, and authenticated MCP tools can initialize correctly without persisting user credentials in the stored harness configuration.

## Validation

- `python -m pytest tests/test_harness.py tests/test_invocations.py -q` — 48 passed
- `npm run build` — passed
