### PR TITLE
fix: fail closed on missing IdP and guard against SSRF in OAuth well-known fetches

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -12,6 +12,28 @@ from app.services.jwt_validator import validate_cognito_token, validate_token
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Local-dev auth bypass (fail-closed by default)
+# ---------------------------------------------------------------------------
+# Historically, the absence of Cognito/IdP config silently granted every
+# request super-admin — including requests with no Authorization header —
+# which is an open admin panel on any deployment that forgets to wire up an
+# IdP. Bypass now requires an explicit opt-in and is further restricted to
+# requests arriving from loopback, so it can't be reached over a network
+# even if the env var is set in a deployed environment by mistake.
+LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV = "LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV"
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+
+def _bypass_auth_enabled() -> bool:
+    return os.getenv(LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV, "").strip().lower() in ("1", "true", "yes")
+
+
+def _is_loopback_request(request: Request) -> bool:
+    client = request.client
+    return bool(client) and client.host in _LOOPBACK_HOSTS
+
+
+# ---------------------------------------------------------------------------
 # Group-to-scope mapping (must match frontend GROUP_SCOPES)
 # ---------------------------------------------------------------------------
 # Users belong to two dimensions:
@@ -202,7 +224,11 @@ def get_current_user(request: Request) -> UserInfo:
     """Extract and validate the Bearer token, returning a UserInfo with derived scopes.
 
     Checks for an active external IdP first. Falls back to Cognito.
-    In bypass mode (LOOM_COGNITO_USER_POOL_ID not set and no active IdP) returns a user with all scopes.
+    In bypass mode (LOOM_COGNITO_USER_POOL_ID not set and no active IdP) returns a
+    user with all scopes, but ONLY when LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV is set
+    AND the request arrives from loopback. Fails closed (401) otherwise, since an
+    IdP-less deployment reachable over the network would otherwise be an open
+    admin panel.
     """
     user_pool_id = os.getenv("LOOM_COGNITO_USER_POOL_ID", "")
     region = os.getenv("LOOM_COGNITO_REGION", os.getenv("AWS_REGION", "us-east-1"))
@@ -213,16 +239,24 @@ def get_current_user(request: Request) -> UserInfo:
     # Check for active external IdP
     active_idp = _get_active_idp_cached()
 
-    # Bypass mode — no Cognito and no external IdP configured
+    # Bypass mode — no Cognito and no external IdP configured. Requires explicit
+    # opt-in and a loopback client; otherwise fail closed with 401.
     if not user_pool_id and not active_idp:
-        logger.warning("No identity provider configured; bypassing auth")
-        return UserInfo(
-            sub="local",
-            username="local-dev",
-            groups=["t-admin", "g-admins-super"],
-            scopes=ALL_SCOPES.copy(),
-            idp_type="local",
+        if _bypass_auth_enabled() and _is_loopback_request(request):
+            logger.warning("No identity provider configured; bypassing auth for loopback request")
+            return UserInfo(
+                sub="local",
+                username="local-dev",
+                groups=["t-admin", "g-admins-super"],
+                scopes=ALL_SCOPES.copy(),
+                idp_type="local",
+            )
+        logger.error(
+            "No identity provider configured and auth bypass not enabled "
+            "(set %s=true for local dev); rejecting request",
+            LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV,
         )
+        raise HTTPException(status_code=401, detail="No identity provider configured")
 
     if not token:
         raise HTTPException(status_code=401, detail="Missing authorization token")

--- a/backend/app/services/a2a.py
+++ b/backend/app/services/a2a.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import httpx
 
+from app.services.net_guard import SSRFBlockedError, safe_get, safe_post
+
 logger = logging.getLogger(__name__)
 
 A2A_REQUEST_TIMEOUT = 30
@@ -34,9 +36,12 @@ def _get_oauth2_token(agent: Any) -> str | None:
 
     if agent.oauth2_well_known_url:
         try:
-            resp = httpx.get(agent.oauth2_well_known_url, timeout=10)
+            resp = safe_get(agent.oauth2_well_known_url, timeout=10)
             resp.raise_for_status()
             token_url = resp.json().get("token_endpoint")
+        except SSRFBlockedError as e:
+            logger.warning("Blocked well-known URL %s: %s", agent.oauth2_well_known_url, e)
+            return None
         except Exception as e:
             logger.warning("Failed to discover token endpoint from %s: %s", agent.oauth2_well_known_url, e)
 
@@ -51,13 +56,16 @@ def _get_oauth2_token(agent: Any) -> str | None:
         }
         if agent.oauth2_scopes:
             data["scope"] = agent.oauth2_scopes
-        resp = httpx.post(token_url, data=data, timeout=10)
+        resp = safe_post(token_url, data=data, timeout=10)
         if resp.status_code == 400 and agent.oauth2_scopes:
             logger.info("Token request with scopes failed, retrying without scopes")
             data.pop("scope", None)
-            resp = httpx.post(token_url, data=data, timeout=10)
+            resp = safe_post(token_url, data=data, timeout=10)
         resp.raise_for_status()
         return resp.json().get("access_token")
+    except SSRFBlockedError as e:
+        logger.warning("Blocked token endpoint %s: %s", token_url, e)
+        return None
     except Exception as e:
         logger.warning("Failed to obtain OAuth2 token: %s", e)
         return None

--- a/backend/app/services/mcp.py
+++ b/backend/app/services/mcp.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import httpx
 
+from app.services.net_guard import SSRFBlockedError, safe_get, safe_post
 from app.services.secrets import get_secret
 
 logger = logging.getLogger(__name__)
@@ -24,9 +25,12 @@ def _get_oauth2_token(server: Any) -> str | None:
     # Discover token endpoint from well-known URL
     if server.oauth2_well_known_url:
         try:
-            resp = httpx.get(server.oauth2_well_known_url, timeout=10)
+            resp = safe_get(server.oauth2_well_known_url, timeout=10)
             resp.raise_for_status()
             token_url = resp.json().get("token_endpoint")
+        except SSRFBlockedError as e:
+            logger.warning("Blocked well-known URL %s: %s", server.oauth2_well_known_url, e)
+            return None
         except Exception as e:
             logger.warning("Failed to discover token endpoint from %s: %s", server.oauth2_well_known_url, e)
 
@@ -41,14 +45,17 @@ def _get_oauth2_token(server: Any) -> str | None:
         }
         if server.oauth2_scopes:
             data["scope"] = server.oauth2_scopes
-        resp = httpx.post(token_url, data=data, timeout=10)
+        resp = safe_post(token_url, data=data, timeout=10)
         if resp.status_code == 400 and server.oauth2_scopes:
             # Retry without scopes — some providers reject unknown scope values
             logger.info("Token request with scopes failed, retrying without scopes")
             data.pop("scope", None)
-            resp = httpx.post(token_url, data=data, timeout=10)
+            resp = safe_post(token_url, data=data, timeout=10)
         resp.raise_for_status()
         return resp.json().get("access_token")
+    except SSRFBlockedError as e:
+        logger.warning("Blocked token endpoint %s: %s", token_url, e)
+        return None
     except Exception as e:
         logger.warning("Failed to obtain OAuth2 token: %s", e)
         return None
@@ -86,10 +93,13 @@ def _get_obo_token(server: Any, user_token: str) -> str | None:
     token_url = None
     discovery: dict = {}
     try:
-        resp = httpx.get(server.oauth2_well_known_url, timeout=10)
+        resp = safe_get(server.oauth2_well_known_url, timeout=10)
         resp.raise_for_status()
         discovery = resp.json()
         token_url = discovery.get("token_endpoint")
+    except SSRFBlockedError as e:
+        logger.warning("Blocked well-known URL %s: %s", server.oauth2_well_known_url, e)
+        return None
     except Exception as e:
         logger.warning("Failed to discover token endpoint from %s: %s", server.oauth2_well_known_url, e)
 
@@ -120,7 +130,7 @@ def _get_obo_token(server: Any, user_token: str) -> str | None:
             }
             if server.oauth2_scopes:
                 data["scope"] = server.oauth2_scopes
-            resp = httpx.post(token_url, data=data, timeout=10)
+            resp = safe_post(token_url, data=data, timeout=10)
         else:
             # Okta RFC 8693 token exchange — use Basic Auth per Okta docs
             import base64 as _b64
@@ -151,7 +161,7 @@ def _get_obo_token(server: Any, user_token: str) -> str | None:
             if exchange_scopes:
                 data["scope"] = exchange_scopes
 
-            resp = httpx.post(token_url, data=data, headers=basic_headers, timeout=10)
+            resp = safe_post(token_url, data=data, headers=basic_headers, timeout=10)
         if resp.status_code != 200:
             logger.warning("OBO token exchange failed (HTTP %d): %s", resp.status_code, resp.text)
             return None

--- a/backend/app/services/net_guard.py
+++ b/backend/app/services/net_guard.py
@@ -1,0 +1,115 @@
+"""SSRF-safe HTTP fetcher for outbound calls to user-supplied URLs.
+
+Used for OAuth2/OIDC discovery ("well-known") documents and the token
+endpoints they advertise, since both are attacker-influenced (an MCP server
+or A2A agent registration supplies the well-known URL, and the discovery
+document supplies the token endpoint). Every call is forced to HTTPS,
+resolved via DNS, and validated against private/loopback/link-local
+(including the 169.254.169.254 cloud metadata address) and other
+non-public ranges. The connection is then pinned to the resolved IP so a
+second DNS lookup at connect time can't rebind the hostname to a different,
+disallowed address after the check has passed.
+"""
+import ipaddress
+import logging
+import socket
+import urllib.parse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class SSRFBlockedError(ValueError):
+    """Raised when a URL is blocked by outbound SSRF protections."""
+
+
+def _is_disallowed_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if ip is not a routable public address."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve_and_validate(hostname: str) -> str:
+    """Resolve hostname and return a single validated public IP to connect to.
+
+    Raises SSRFBlockedError if resolution fails or any resolved address is
+    non-public. Returning one pinned address (rather than letting the HTTP
+    client re-resolve at connect time) prevents DNS-rebinding between the
+    check and the actual connection.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise SSRFBlockedError(f"DNS resolution failed for {hostname!r}: {e}") from e
+
+    resolved_ips = {info[4][0] for info in infos}
+    if not resolved_ips:
+        raise SSRFBlockedError(f"No addresses resolved for {hostname!r}")
+
+    for ip_str in resolved_ips:
+        ip = ipaddress.ip_address(ip_str)
+        if _is_disallowed_ip(ip):
+            raise SSRFBlockedError(f"{hostname!r} resolves to disallowed address {ip_str}")
+
+    return next(iter(resolved_ips))
+
+
+def _safe_request(
+    method: str,
+    url: str,
+    *,
+    data: dict | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 10,
+) -> httpx.Response:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https":
+        raise SSRFBlockedError(f"Disallowed URL scheme {parsed.scheme!r}; only https is permitted")
+    if not parsed.hostname:
+        raise SSRFBlockedError(f"URL has no hostname: {url!r}")
+
+    validated_ip = _resolve_and_validate(parsed.hostname)
+
+    port = parsed.port or 443
+    is_ipv6 = ":" in validated_ip
+    pinned_host = f"[{validated_ip}]" if is_ipv6 else validated_ip
+    pinned_netloc = f"{pinned_host}:{port}"
+    pinned_url = parsed._replace(netloc=pinned_netloc).geturl()
+
+    request_headers = dict(headers or {})
+    request_headers.setdefault("Host", parsed.hostname)
+
+    request = httpx.Request(
+        method,
+        pinned_url,
+        data=data,
+        headers=request_headers,
+        extensions={"sni_hostname": parsed.hostname},
+    )
+    with httpx.Client(timeout=timeout) as client:
+        return client.send(request)
+
+
+def safe_get(url: str, *, headers: dict[str, str] | None = None, timeout: float = 10) -> httpx.Response:
+    """SSRF-guarded GET. Use for well-known/OIDC discovery documents."""
+    return _safe_request("GET", url, headers=headers, timeout=timeout)
+
+
+def safe_post(
+    url: str,
+    *,
+    data: dict | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 10,
+) -> httpx.Response:
+    """SSRF-guarded POST. Use for token endpoints discovered from a well-known document."""
+    return _safe_request("POST", url, data=data, headers=headers, timeout=timeout)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest fixtures for the backend test suite.
+
+Most tests exercise business logic through scope-gated routers and don't
+care about auth semantics — they rely on the local-dev bypass in
+app.dependencies.auth being active. That bypass now requires an explicit
+opt-in (LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV) plus a loopback client,
+instead of activating automatically. This fixture supplies both by default
+so the rest of the suite doesn't need to change. test_auth.py and
+test_scopes.py override this fixture with a no-op since they exercise the
+bypass mechanics directly and need to control auth state precisely.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _default_auth_bypass(monkeypatch):
+    monkeypatch.setenv("LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV", "true")
+    monkeypatch.setattr("app.dependencies.auth._is_loopback_request", lambda request: True)
+    yield

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -7,12 +7,19 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 import jwt
+import pytest
 
 from app.main import app
 from app.db import Base, get_db
 from app.models.agent import Agent
 from app.services.jwt_validator import validate_cognito_token
 from app.dependencies.auth import derive_scopes
+
+
+@pytest.fixture(autouse=True)
+def _default_auth_bypass():
+    """Override the suite-wide auto-bypass fixture — this module tests bypass mechanics directly."""
+    yield
 
 
 class TestAuthConfigEndpoint(unittest.TestCase):
@@ -84,7 +91,7 @@ class TestJWTValidator(unittest.TestCase):
 
 
 class TestInvokeEndpointWithoutAuth(unittest.TestCase):
-    """Regression test: invoke endpoint works without auth headers."""
+    """Auth bypass now fails closed by default and requires explicit opt-in + loopback."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -131,13 +138,23 @@ class TestInvokeEndpointWithoutAuth(unittest.TestCase):
         Base.metadata.drop_all(bind=self.engine)
         Base.metadata.create_all(bind=self.engine)
 
+    @patch.dict("os.environ", {}, clear=True)
+    def test_invoke_without_auth_header_rejected_by_default(self) -> None:
+        """No IdP configured and no bypass opt-in: invoke is rejected, not silently admin."""
+        response = self.client.post(
+            f"/api/agents/{self.agent.id}/invoke",
+            json={"prompt": "Test prompt", "qualifier": "DEFAULT"},
+        )
+        self.assertEqual(response.status_code, 401)
+
+    @patch.dict("os.environ", {"LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV": "true"}, clear=True)
     @patch("app.routers.invocations.get_log_events")
     @patch("app.routers.invocations.parse_agent_start_time")
     @patch("app.routers.invocations.compute_cold_start")
     @patch("app.routers.invocations.derive_log_group")
     @patch("app.routers.invocations.invoke_agent")
     @patch("app.routers.invocations.compute_client_duration")
-    def test_invoke_without_auth_header_still_works(
+    def test_invoke_without_auth_header_works_with_explicit_loopback_bypass(
         self,
         mock_compute_duration,
         mock_invoke,
@@ -146,14 +163,15 @@ class TestInvokeEndpointWithoutAuth(unittest.TestCase):
         mock_parse_agent_start,
         mock_get_log_events,
     ) -> None:
-        """Test that invoke works without Authorization header (regression)."""
+        """With LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV set and a loopback client, bypass still works."""
         mock_invoke.return_value = iter([{"type": "text", "content": "Hello"}])
         mock_compute_duration.return_value = 1000.0
         mock_derive_log_group.return_value = "/aws/bedrock-agentcore/runtimes/test-agent-DEFAULT"
         mock_get_log_events.return_value = []
         mock_parse_agent_start.return_value = None
 
-        response = self.client.post(
+        loopback_client = TestClient(app, client=("127.0.0.1", 12345))
+        response = loopback_client.post(
             f"/api/agents/{self.agent.id}/invoke",
             json={"prompt": "Test prompt", "qualifier": "DEFAULT"},
         )
@@ -162,6 +180,15 @@ class TestInvokeEndpointWithoutAuth(unittest.TestCase):
         self.assertIn("event: session_start", response.text)
         self.assertIn("event: chunk", response.text)
         self.assertIn("event: session_end", response.text)
+
+    @patch.dict("os.environ", {"LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV": "true"}, clear=True)
+    def test_invoke_without_auth_header_still_rejected_when_not_loopback(self) -> None:
+        """Bypass opt-in alone is not enough — a non-loopback client is still rejected."""
+        response = self.client.post(
+            f"/api/agents/{self.agent.id}/invoke",
+            json={"prompt": "Test prompt", "qualifier": "DEFAULT"},
+        )
+        self.assertEqual(response.status_code, 401)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_mcp_ssrf.py
+++ b/backend/tests/test_mcp_ssrf.py
@@ -1,0 +1,113 @@
+"""Regression tests for the SSRF / user-token-leak fix in app.services.mcp.
+
+Reproduces the reported attack: an MCP server's oauth2_well_known_url is
+attacker-controlled (set via POST /api/mcp/servers or the test-connection
+endpoint). Before the fix, _get_oauth2_token/_get_obo_token fetched that URL
+and the token_endpoint it returned with no validation — reaching internal
+addresses (SSRF) and, in OBO mode, forwarding the caller's real access
+token as the OAuth subject_token to whatever host the attacker named.
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.services.mcp import _get_oauth2_token, _get_obo_token
+
+
+def _make_server(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        auth_type="oauth2",
+        oauth2_well_known_url="https://169.254.169.254/.well-known/openid-configuration",
+        oauth2_client_id="client",
+        oauth2_client_secret="secret",  # nosec B106
+        oauth2_scopes=None,
+        oauth2_audience=None,
+        delegation_mode="obo",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestOauth2TokenSSRFGuard(unittest.TestCase):
+    """_get_oauth2_token (client-credentials / m2m path)."""
+
+    def test_well_known_url_pointing_at_metadata_address_is_blocked(self) -> None:
+        server = _make_server()
+        with patch("httpx.get") as mock_get, patch("httpx.post") as mock_post:
+            token = _get_oauth2_token(server)
+        self.assertIsNone(token)
+        mock_get.assert_not_called()
+        mock_post.assert_not_called()
+
+    def test_well_known_url_pointing_at_loopback_is_blocked(self) -> None:
+        server = _make_server(oauth2_well_known_url="http://127.0.0.1:9011/.well-known/openid-configuration")
+        with patch("httpx.get") as mock_get, patch("httpx.post") as mock_post:
+            token = _get_oauth2_token(server)
+        self.assertIsNone(token)
+        mock_get.assert_not_called()
+        mock_post.assert_not_called()
+
+    def test_discovered_token_endpoint_pointing_at_private_ip_is_blocked(self) -> None:
+        """Even a legitimate-looking https well-known host must not be able to
+        redirect the token exchange to an internal token_endpoint."""
+        server = _make_server(oauth2_well_known_url="https://auth.example.com/.well-known/openid-configuration")
+        with patch("app.services.mcp.safe_get") as mock_safe_get, \
+             patch("httpx.post") as mock_post:
+            mock_safe_get.return_value.raise_for_status.return_value = None
+            mock_safe_get.return_value.json.return_value = {"token_endpoint": "http://10.0.0.5/collect"}
+            token = _get_oauth2_token(server)
+        self.assertIsNone(token)
+        mock_post.assert_not_called()
+
+
+class TestOboTokenSSRFGuardAndTokenLeak(unittest.TestCase):
+    """_get_obo_token — the finding's headline scenario: a real user access
+    token must never be forwarded to an attacker-controlled endpoint."""
+
+    def test_well_known_url_pointing_at_attacker_listener_blocks_before_forwarding_user_token(self) -> None:
+        server = _make_server(oauth2_well_known_url="http://127.0.0.1:9011/.well-known/openid-configuration")
+        victim_token = "victim-cognito-access-token"  # nosec B105
+        with patch("httpx.get") as mock_get, patch("httpx.post") as mock_post:
+            result = _get_obo_token(server, victim_token)
+        self.assertIsNone(result)
+        # The victim's token must never have been sent anywhere.
+        mock_get.assert_not_called()
+        mock_post.assert_not_called()
+
+    def test_discovered_token_endpoint_pointing_at_metadata_blocks_before_forwarding_user_token(self) -> None:
+        server = _make_server(oauth2_well_known_url="https://auth.example.com/.well-known/openid-configuration")
+        victim_token = "victim-cognito-access-token"  # nosec B105
+        with patch("app.services.mcp.safe_get") as mock_safe_get, \
+             patch("httpx.post") as mock_post:
+            mock_safe_get.return_value.raise_for_status.return_value = None
+            mock_safe_get.return_value.json.return_value = {
+                "token_endpoint": "http://169.254.169.254/latest/meta-data/collect",
+            }
+            result = _get_obo_token(server, victim_token)
+        self.assertIsNone(result)
+        mock_post.assert_not_called()
+
+    def test_legitimate_https_endpoints_still_work(self) -> None:
+        """Sanity check: the guard doesn't break the legitimate Okta OBO path."""
+        server = _make_server(
+            oauth2_well_known_url="https://auth.example.com/.well-known/openid-configuration",
+            oauth2_audience="api://downstream",
+        )
+        victim_token = "victim-cognito-access-token"  # nosec B105
+        with patch("app.services.mcp.safe_get") as mock_safe_get, \
+             patch("app.services.mcp.safe_post") as mock_safe_post:
+            mock_safe_get.return_value.raise_for_status.return_value = None
+            mock_safe_get.return_value.json.return_value = {
+                "token_endpoint": "https://auth.example.com/oauth2/v1/token",
+            }
+            mock_safe_post.return_value.status_code = 200
+            mock_safe_post.return_value.json.return_value = {"access_token": "downstream-token"}
+            result = _get_obo_token(server, victim_token)
+        self.assertEqual(result, "downstream-token")
+        # Confirm the victim token was sent only to the validated https endpoint.
+        _, kwargs = mock_safe_post.call_args
+        self.assertEqual(kwargs["data"]["subject_token"], victim_token)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_net_guard.py
+++ b/backend/tests/test_net_guard.py
@@ -1,0 +1,98 @@
+"""Tests for the SSRF-safe outbound fetcher used for OAuth2/OIDC well-known
+and token-endpoint calls (mcp.py / a2a.py). These calls are attacker
+influenced: an MCP server or A2A agent registration supplies the well-known
+URL, and the discovery document supplies the token endpoint.
+"""
+import socket
+import unittest
+from unittest.mock import patch, MagicMock
+
+from app.services.net_guard import SSRFBlockedError, _is_disallowed_ip, safe_get, safe_post
+import ipaddress
+
+
+class TestIsDisallowedIp(unittest.TestCase):
+    def test_private_ipv4_blocked(self) -> None:
+        self.assertTrue(_is_disallowed_ip(ipaddress.ip_address("10.0.0.5")))
+        self.assertTrue(_is_disallowed_ip(ipaddress.ip_address("192.168.1.1")))
+        self.assertTrue(_is_disallowed_ip(ipaddress.ip_address("172.16.0.1")))
+
+    def test_loopback_blocked(self) -> None:
+        self.assertTrue(_is_disallowed_ip(ipaddress.ip_address("127.0.0.1")))
+        self.assertTrue(_is_disallowed_ip(ipaddress.ip_address("::1")))
+
+    def test_link_local_and_metadata_blocked(self) -> None:
+        self.assertTrue(_is_disallowed_ip(ipaddress.ip_address("169.254.169.254")))
+        self.assertTrue(_is_disallowed_ip(ipaddress.ip_address("169.254.0.1")))
+
+    def test_ipv4_mapped_ipv6_blocked(self) -> None:
+        """::ffff:169.254.169.254 must be unwrapped and checked as the mapped IPv4 address."""
+        self.assertTrue(_is_disallowed_ip(ipaddress.ip_address("::ffff:169.254.169.254")))
+
+    def test_public_ip_allowed(self) -> None:
+        self.assertFalse(_is_disallowed_ip(ipaddress.ip_address("93.184.216.34")))
+
+
+class TestSafeGetPost(unittest.TestCase):
+    def test_rejects_non_https_scheme(self) -> None:
+        with self.assertRaises(SSRFBlockedError):
+            safe_get("http://example.com/.well-known/openid-configuration")
+
+    def test_rejects_file_scheme(self) -> None:
+        with self.assertRaises(SSRFBlockedError):
+            safe_get("file:///etc/passwd")
+
+    def test_rejects_loopback_host(self) -> None:
+        with self.assertRaises(SSRFBlockedError):
+            safe_get("https://127.0.0.1/attacker")
+
+    def test_rejects_metadata_ip(self) -> None:
+        with self.assertRaises(SSRFBlockedError):
+            safe_get("https://169.254.169.254/latest/meta-data/")
+
+    def test_rejects_hostname_resolving_to_private_ip(self) -> None:
+        """Attacker-controlled DNS pointing a public-looking hostname at a private IP is blocked."""
+        with patch("socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("10.1.2.3", 443))]
+            with self.assertRaises(SSRFBlockedError):
+                safe_get("https://evil.example.com/.well-known/openid-configuration")
+
+    def test_rejects_dns_resolution_failure(self) -> None:
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("nope")):
+            with self.assertRaises(SSRFBlockedError):
+                safe_get("https://nonexistent.invalid/")
+
+    def test_pins_connection_to_resolved_ip_and_sets_sni(self) -> None:
+        """The request goes out to the resolved IP (not left to re-resolve), with SNI/Host preserved."""
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("93.184.216.34", 443))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_response = MagicMock(status_code=200)
+            mock_client.send.return_value = mock_response
+
+            safe_get("https://example.com/.well-known/openid-configuration")
+
+            sent_request = mock_client.send.call_args[0][0]
+            self.assertIn("93.184.216.34", str(sent_request.url))
+            self.assertEqual(sent_request.extensions.get("sni_hostname"), "example.com")
+            self.assertEqual(sent_request.headers.get("host"), "example.com")
+
+    def test_safe_post_sends_form_data_to_pinned_ip(self) -> None:
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("93.184.216.34", 443))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.send.return_value = MagicMock(status_code=200)
+
+            safe_post("https://example.com/token", data={"grant_type": "client_credentials"})
+
+            sent_request = mock_client.send.call_args[0][0]
+            self.assertIn("93.184.216.34", str(sent_request.url))
+            self.assertEqual(sent_request.method, "POST")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_scopes.py
+++ b/backend/tests/test_scopes.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -17,6 +18,12 @@ from app.dependencies.auth import (
     get_current_user,
     require_scopes,
 )
+
+
+@pytest.fixture(autouse=True)
+def _default_auth_bypass():
+    """Override the suite-wide auto-bypass fixture — TestBypassMode tests bypass mechanics directly."""
+    yield
 
 
 # ---------------------------------------------------------------------------
@@ -200,17 +207,23 @@ class TestScopeEnforcement(unittest.TestCase):
 
 
 class TestBypassMode(unittest.TestCase):
-    """Test that bypass mode grants all scopes when Cognito is not configured."""
+    """Test that bypass mode grants all scopes only with explicit opt-in + loopback."""
 
     def setUp(self) -> None:
-        self.client = TestClient(app)
+        self.client = TestClient(app, client=("127.0.0.1", 12345))
 
-    @patch.dict("os.environ", {}, clear=True)
+    @patch.dict("os.environ", {"LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV": "true"}, clear=True)
     def test_bypass_mode_returns_all_scopes(self) -> None:
-        """When LOOM_COGNITO_USER_POOL_ID is not set, all scopes are granted."""
+        """With the opt-in set and a loopback client, all scopes are granted."""
         response = self.client.get("/api/agents")
         # Should succeed because bypass mode gives all scopes
         self.assertIn(response.status_code, [200, 500])  # 200 or 500 (no AWS), but not 401/403
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_bypass_mode_disabled_by_default(self) -> None:
+        """Without the opt-in, no identity provider configured means requests are rejected."""
+        response = self.client.get("/api/agents")
+        self.assertEqual(response.status_code, 401)
 
 
 if __name__ == "__main__":

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loom-frontend",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loom-frontend",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
## Summary
Remediates two internally-reported security findings in the FastAPI backend:

- **Fail-open auth bypass**: when no Cognito pool and no external IdP were configured, `get_current_user` silently granted every request — including unauthenticated ones — `t-admin`/`g-admins-super` (full scope set). Now requires an explicit `LOOM_ALLOW_UNAUTHENTICATED_LOCAL_DEV=true` opt-in **and** a loopback client; otherwise fails closed with `401`.
- **SSRF + user-token leak via OAuth well-known URL**: `oauth2_well_known_url` (user-supplied on MCP server / A2A agent registration) and the `token_endpoint` it resolves to were fetched with no validation — reachable from any scheme/host, including internal and cloud-metadata addresses, and in OBO mode the request carried the caller's real access token. Added `app/services/net_guard.py`, a hardened fetcher that forces HTTPS, resolves and rejects private/loopback/link-local/metadata addresses, and pins the connection to the validated IP (preventing DNS rebinding). Wired into `mcp.py` and `a2a.py`.

## Test plan
- [x] `tests/test_auth.py`, `tests/test_scopes.py` — bypass rejected by default; opt-in + loopback works; opt-in alone (non-loopback) still rejected
- [x] `tests/test_net_guard.py` — IP classification (private/loopback/link-local/metadata/mapped-IPv6), scheme rejection, DNS-rebinding pin behavior, DNS-failure handling
- [x] `tests/test_mcp_ssrf.py` — well-known pointed at loopback/metadata blocked before any HTTP call; discovered `token_endpoint` pointed at a private IP blocked even behind a legitimate-looking HTTPS well-known host; legitimate OBO flow still succeeds
- [x] Added `tests/conftest.py` so the ~300 other tests that implicitly relied on the old auto-bypass continue to pass under the new fail-closed default
- [x] Full suite: 640 passed, 6 pre-existing unrelated failures (confirmed present on `main` before this change)
- [x] Live-reproduced both PoCs from the original report against a running instance — both now return 401 (finding 1) / blocked with no outbound request (finding 2)