### PR TITLE
fix: guard MCP/A2A connection sinks against SSRF

### DIFF
--- a/backend/SPECIFICATIONS.md
+++ b/backend/SPECIFICATIONS.md
@@ -1211,6 +1211,15 @@ Core authentication and authorization module. Provides:
 
 **View As mode:** Super-admins can switch to view the system as a different user persona (e.g., `demo-admin`, `demo-user`). The frontend sends a `group` parameter to backend endpoints, which filters resources as if the admin belonged to that group. This enables super-admins to validate permission models without switching accounts.
 
+### `services/net_guard.py`
+
+SSRF-safe HTTP fetchers for outbound calls to user-supplied URLs, at two guard levels reflecting different trust models:
+
+- `safe_get(url, headers=None, timeout=10) -> Response`, `safe_post(url, data=None, headers=None, timeout=10) -> Response` — strict, public-addresses-only. Forces HTTPS, resolves the hostname via DNS, and rejects private/loopback/link-local (including the `169.254.169.254` cloud metadata address)/multicast/reserved/unspecified addresses. Used for OAuth2/OIDC discovery ("well-known") documents and the token endpoints they advertise (`mcp.py`/`a2a.py`'s `_get_oauth2_token`/`_get_obo_token`), since both are attacker-influenced (the well-known URL comes from an MCP server/A2A agent registration, and the discovery document supplies the token endpoint) and legitimate identity providers are always public internet-facing services.
+- `guarded_get(url, headers=None, timeout=10, follow_redirects=True) -> Response`, `guarded_post(url, json=None, headers=None, timeout=10, follow_redirects=True) -> Response` — permissive, allows both `http`/`https` and private (RFC 1918/RFC 4193) addresses, but still always blocks cloud metadata, loopback, link-local, multicast, reserved, and unspecified addresses. Used for the actual MCP server `endpoint_url` / A2A agent `base_url` connection targets — unlike OAuth infrastructure, reaching a private/VPC-internal address is a legitimate, supported use case here (the backend ECS service runs in private subnets specifically to support VPC-internal MCP servers and A2A agents).
+- Both levels resolve the hostname once via `socket.getaddrinfo` and pin the outbound connection to that validated IP (rather than letting the HTTP client re-resolve at connect time), preventing DNS-rebinding between the check and the actual connection. `guarded_get`/`guarded_post` additionally re-validate every redirect hop before following it (up to 5 hops, `SSRFBlockedError` beyond that) — an initial target passing validation does not grant a later cross-host redirect target a pass.
+- `SSRFBlockedError(ValueError)` — raised by both levels when a URL is blocked; callers catch it separately from generic connection errors to log/return a distinct "blocked" outcome without ever surfacing the disallowed target's response body.
+
 ### `services/mcp.py`
 
 MCP server connection, tool discovery, and invocation:
@@ -1220,13 +1229,13 @@ MCP server connection, tool discovery, and invocation:
 - `invoke_mcp_tool(server, tool_name, arguments, api_key=None) -> dict` — Calls `tools/call` JSON-RPC method to invoke a specific tool with arguments.
 - `resolve_api_key(server, user_sub=None) -> str | None` — Resolves API key from Secrets Manager. Admin key for admin context (`loom/mcp/{name}/admin-api-key`), user key for user context (`loom/mcp/{name}/api-key/{user_sub}`).
 - `_build_headers(server, api_key=None) -> dict` — Builds request headers with auth injection. For API key auth, uses `api_key_header_name` to set the correct header; `Authorization` headers are prefixed with `Bearer`.
-- `_call_streamable_http()`, `_call_sse()`, `_call_mcp()` — Transport methods accepting optional `api_key` parameter.
+- `_call_streamable_http()`, `_initialize_session()`, `_call_sse()`, `_call_mcp()` — Transport methods accepting optional `api_key` parameter. All POST to `server.endpoint_url` via `net_guard.guarded_post` (SSRF-guarded, private/VPC addresses allowed) rather than a raw `httpx.post`, since `endpoint_url` is user-supplied at MCP server registration; `SSRFBlockedError` is caught and logged as a blocked connection (returns `None`, same as any other connection failure).
 
 ### `services/a2a.py`
 
 A2A Agent Card fetching and connection testing:
 
-- `fetch_agent_card(base_url: str, auth_headers: dict | None) -> dict` — fetches the Agent Card from the well-known endpoint. Standard A2A agents use `/.well-known/agent.json`; AgentCore agents try `/.well-known/agent-card.json` first; Salesforce Agentforce agents use `/v1/card`. Raises on HTTP errors or invalid JSON.
+- `fetch_agent_card(base_url: str, auth_headers: dict | None) -> dict` — fetches the Agent Card from the well-known endpoint via `net_guard.guarded_get` (SSRF-guarded, private/VPC addresses allowed, since `base_url` is user-supplied at A2A agent registration). Standard A2A agents use `/.well-known/agent.json`; AgentCore agents try `/.well-known/agent-card.json` first; Salesforce Agentforce agents use `/v1/card` via `_fetch_salesforce_agent_card`, also guarded. Raises `ValueError` on HTTP errors, invalid JSON, or an `SSRFBlockedError` (mapped to a `ValueError` without echoing any part of the blocked target's response). Error messages for non-2xx statuses use a fixed friendly string rather than the response body, since the connection target is attacker-influenced and echoing response content back to the caller would make the endpoint usable as a blind-SSRF response oracle.
 - `parse_agent_card(card_json: dict) -> dict` — extracts structured fields (name, description, version, provider, capabilities, authentication, skills, etc.) from raw Agent Card JSON.
 - `sync_skills(db: Session, agent_id: int, skills: list[dict])` — synchronizes skills from Agent Card to the database. Adds new skills, removes stale ones.
 - `test_a2a_connection(agent) -> dict` — acquires OAuth2 token if configured and fetches the Agent Card, returning success/failure with details.

--- a/backend/app/services/a2a.py
+++ b/backend/app/services/a2a.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import httpx
 
-from app.services.net_guard import SSRFBlockedError, safe_get, safe_post
+from app.services.net_guard import SSRFBlockedError, guarded_get, safe_get, safe_post
 
 logger = logging.getLogger(__name__)
 
@@ -97,16 +97,18 @@ def _fetch_salesforce_agent_card(base_url: str, headers: dict[str, str]) -> dict
     """
     url = base_url + "/v1/card"
     try:
-        resp = httpx.get(url, headers=headers, timeout=A2A_REQUEST_TIMEOUT, follow_redirects=True)
+        resp = guarded_get(url, headers=headers, timeout=A2A_REQUEST_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
+    except SSRFBlockedError as e:
+        raise ValueError(f"Blocked Salesforce Agent Card URL: {e}") from e
     except httpx.HTTPStatusError as e:
         status_code = e.response.status_code
         friendly = {
             401: "authentication required — check OAuth2 credentials",
             403: "access denied — check OAuth2 credentials and scopes",
         }
-        detail = friendly.get(status_code, e.response.text[:200])
+        detail = friendly.get(status_code, "the remote server returned an error")
         raise ValueError(f"Salesforce Agent Card fetch failed (HTTP {status_code}): {detail}") from e
     except httpx.ConnectError as e:
         raise ValueError(f"Cannot connect to {base_url} — verify the URL is correct") from e
@@ -146,9 +148,11 @@ def fetch_agent_card(base_url: str, auth_headers: dict[str, str] | None = None) 
     for path in paths:
         url = stripped + path
         try:
-            resp = httpx.get(url, headers=headers, timeout=A2A_REQUEST_TIMEOUT, follow_redirects=True)
+            resp = guarded_get(url, headers=headers, timeout=A2A_REQUEST_TIMEOUT)
             resp.raise_for_status()
             break
+        except SSRFBlockedError as e:
+            raise ValueError(f"Blocked Agent Card URL: {e}") from e
         except httpx.HTTPStatusError as e:
             last_error = e
             status = e.response.status_code
@@ -163,7 +167,7 @@ def fetch_agent_card(base_url: str, auth_headers: dict[str, str] | None = None) 
                 502: "bad gateway — the remote server may be down",
                 503: "the remote server is unavailable",
             }
-            detail = friendly.get(status, e.response.text[:200])
+            detail = friendly.get(status, "the remote server returned an error")
             raise ValueError(f"Agent Card fetch failed (HTTP {status}): {detail}") from e
         except httpx.ConnectError as e:
             raise ValueError(f"Cannot connect to {base_url} — verify the URL is correct and the server is running") from e

--- a/backend/app/services/mcp.py
+++ b/backend/app/services/mcp.py
@@ -4,9 +4,7 @@ import logging
 import os
 from typing import Any
 
-import httpx
-
-from app.services.net_guard import SSRFBlockedError, safe_get, safe_post
+from app.services.net_guard import SSRFBlockedError, guarded_post, safe_get, safe_post
 from app.services.secrets import get_secret
 
 logger = logging.getLogger(__name__)
@@ -230,7 +228,7 @@ def _call_streamable_http(server: Any, method: str, params: dict | None = None, 
                 headers["Mcp-Session-Id"] = session_id
 
         body = _jsonrpc_request(method, params)
-        resp = httpx.post(
+        resp = guarded_post(
             server.endpoint_url,
             json=body,
             headers=headers,
@@ -246,6 +244,9 @@ def _call_streamable_http(server: Any, method: str, params: dict | None = None, 
             return _parse_sse_response(resp.text)
         else:
             return resp.json()
+    except SSRFBlockedError as e:
+        logger.warning("Blocked MCP endpoint %s: %s", server.endpoint_url, e)
+        return None
     except Exception as e:
         logger.error("Streamable HTTP call to %s failed: %s", server.endpoint_url, e)
         return None
@@ -260,7 +261,7 @@ def _initialize_session(server: Any, headers: dict[str, str]) -> str | None:
     })
 
     try:
-        resp = httpx.post(
+        resp = guarded_post(
             server.endpoint_url,
             json=init_body,
             headers=headers,
@@ -287,7 +288,7 @@ def _call_sse(server: Any, method: str, params: dict | None = None, api_key: str
     body = _jsonrpc_request(method, params)
 
     try:
-        resp = httpx.post(
+        resp = guarded_post(
             server.endpoint_url,
             json=body,
             headers=headers,
@@ -300,6 +301,9 @@ def _call_sse(server: Any, method: str, params: dict | None = None, api_key: str
             return _parse_sse_response(resp.text)
         else:
             return resp.json()
+    except SSRFBlockedError as e:
+        logger.warning("Blocked MCP endpoint %s: %s", server.endpoint_url, e)
+        return None
     except Exception as e:
         logger.error("SSE call to %s failed: %s", server.endpoint_url, e)
         return None

--- a/backend/app/services/net_guard.py
+++ b/backend/app/services/net_guard.py
@@ -1,14 +1,34 @@
-"""SSRF-safe HTTP fetcher for outbound calls to user-supplied URLs.
+"""SSRF-safe HTTP fetchers for outbound calls to user-supplied URLs.
 
-Used for OAuth2/OIDC discovery ("well-known") documents and the token
-endpoints they advertise, since both are attacker-influenced (an MCP server
-or A2A agent registration supplies the well-known URL, and the discovery
-document supplies the token endpoint). Every call is forced to HTTPS,
-resolved via DNS, and validated against private/loopback/link-local
-(including the 169.254.169.254 cloud metadata address) and other
-non-public ranges. The connection is then pinned to the resolved IP so a
-second DNS lookup at connect time can't rebind the hostname to a different,
-disallowed address after the check has passed.
+Two guard levels are provided, since Loom's outbound calls fall into two
+different trust models:
+
+- ``safe_get``/``safe_post`` (strict, public-only): used for OAuth2/OIDC
+  discovery ("well-known") documents and the token endpoints they advertise,
+  since both are attacker-influenced (an MCP server or A2A agent
+  registration supplies the well-known URL, and the discovery document
+  supplies the token endpoint) and legitimate identity providers are always
+  public internet-facing services. Every call is forced to HTTPS, resolved
+  via DNS, and validated against private/loopback/link-local (including the
+  169.254.169.254 cloud metadata address) and other non-public ranges.
+
+- ``guarded_get``/``guarded_post`` (permissive, connection sinks): used for
+  the actual MCP server / A2A agent connection targets
+  (``endpoint_url``/``base_url``). Unlike OAuth infrastructure, reaching a
+  private/VPC-internal address is a legitimate, documented use case here —
+  the backend runs in private subnets specifically to support VPC-internal
+  MCP servers and A2A agents, and HTTP (not just HTTPS) is a supported
+  scheme for local/internal deployments. These guards therefore allow
+  private (RFC 1918/RFC 4193) addresses through, but still always block the
+  cloud metadata address, loopback, link-local, multicast, reserved, and
+  unspecified addresses, since none of those are legitimate MCP/A2A targets.
+
+Both levels resolve the hostname once and pin the connection to the
+validated IP so a second DNS lookup at connect time can't rebind the
+hostname to a different, disallowed address after the check has passed
+(DNS rebinding). ``guarded_get``/``guarded_post`` additionally re-validate
+every redirect hop before following it, since an initial target can pass
+validation and then redirect to a disallowed address.
 """
 import ipaddress
 import logging
@@ -19,18 +39,27 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+# Maximum number of redirect hops guarded_get/guarded_post will follow,
+# re-validating the target at each hop.
+_MAX_REDIRECTS = 5
+
 
 class SSRFBlockedError(ValueError):
     """Raised when a URL is blocked by outbound SSRF protections."""
 
 
-def _is_disallowed_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    """Return True if ip is not a routable public address."""
+def _is_always_disallowed_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if ip must never be reachable, regardless of guard level.
+
+    Covers the cloud metadata address (a link-local address), loopback,
+    other link-local addresses, multicast, reserved, and unspecified — none
+    of which are legitimate targets for either OAuth infrastructure or a
+    user-configured MCP server / A2A agent.
+    """
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
         ip = ip.ipv4_mapped
     return (
-        ip.is_private
-        or ip.is_loopback
+        ip.is_loopback
         or ip.is_link_local
         or ip.is_multicast
         or ip.is_reserved
@@ -38,13 +67,22 @@ def _is_disallowed_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool
     )
 
 
-def _resolve_and_validate(hostname: str) -> str:
-    """Resolve hostname and return a single validated public IP to connect to.
+def _is_disallowed_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if ip is not a routable public address (strict/public-only mode)."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip.is_private or _is_always_disallowed_ip(ip)
 
-    Raises SSRFBlockedError if resolution fails or any resolved address is
-    non-public. Returning one pinned address (rather than letting the HTTP
-    client re-resolve at connect time) prevents DNS-rebinding between the
-    check and the actual connection.
+
+def _resolve_and_validate(hostname: str, *, allow_private: bool = False) -> str:
+    """Resolve hostname and return a single validated IP to connect to.
+
+    Raises SSRFBlockedError if resolution fails, or if any resolved address
+    is disallowed for the requested guard level (always-disallowed
+    addresses are rejected regardless of ``allow_private``). Returning one
+    pinned address (rather than letting the HTTP client re-resolve at
+    connect time) prevents DNS-rebinding between the check and the actual
+    connection.
     """
     try:
         infos = socket.getaddrinfo(hostname, None)
@@ -55,12 +93,56 @@ def _resolve_and_validate(hostname: str) -> str:
     if not resolved_ips:
         raise SSRFBlockedError(f"No addresses resolved for {hostname!r}")
 
+    is_disallowed = _is_always_disallowed_ip if allow_private else _is_disallowed_ip
     for ip_str in resolved_ips:
         ip = ipaddress.ip_address(ip_str)
-        if _is_disallowed_ip(ip):
+        if is_disallowed(ip):
             raise SSRFBlockedError(f"{hostname!r} resolves to disallowed address {ip_str}")
 
     return next(iter(resolved_ips))
+
+
+def _validate_url(url: str, *, require_https: bool, allow_private: bool) -> tuple[urllib.parse.ParseResult, str]:
+    """Validate a URL's scheme and resolved address; return (parsed, pinned_ip)."""
+    parsed = urllib.parse.urlparse(url)
+    allowed_schemes = ("https",) if require_https else ("http", "https")
+    if parsed.scheme not in allowed_schemes:
+        raise SSRFBlockedError(f"Disallowed URL scheme {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise SSRFBlockedError(f"URL has no hostname: {url!r}")
+
+    validated_ip = _resolve_and_validate(parsed.hostname, allow_private=allow_private)
+    return parsed, validated_ip
+
+
+def _build_pinned_request(
+    method: str,
+    parsed: urllib.parse.ParseResult,
+    validated_ip: str,
+    *,
+    data: dict | None = None,
+    json: dict | None = None,
+    headers: dict[str, str] | None = None,
+) -> httpx.Request:
+    default_port = 443 if parsed.scheme == "https" else 80
+    port = parsed.port or default_port
+    is_ipv6 = ":" in validated_ip
+    pinned_host = f"[{validated_ip}]" if is_ipv6 else validated_ip
+    pinned_netloc = f"{pinned_host}:{port}"
+    pinned_url = parsed._replace(netloc=pinned_netloc).geturl()
+
+    request_headers = dict(headers or {})
+    request_headers.setdefault("Host", parsed.hostname)
+
+    extensions = {"sni_hostname": parsed.hostname} if parsed.scheme == "https" else {}
+    return httpx.Request(
+        method,
+        pinned_url,
+        data=data,
+        json=json,
+        headers=request_headers,
+        extensions=extensions,
+    )
 
 
 def _safe_request(
@@ -71,36 +153,15 @@ def _safe_request(
     headers: dict[str, str] | None = None,
     timeout: float = 10,
 ) -> httpx.Response:
-    parsed = urllib.parse.urlparse(url)
-    if parsed.scheme != "https":
-        raise SSRFBlockedError(f"Disallowed URL scheme {parsed.scheme!r}; only https is permitted")
-    if not parsed.hostname:
-        raise SSRFBlockedError(f"URL has no hostname: {url!r}")
-
-    validated_ip = _resolve_and_validate(parsed.hostname)
-
-    port = parsed.port or 443
-    is_ipv6 = ":" in validated_ip
-    pinned_host = f"[{validated_ip}]" if is_ipv6 else validated_ip
-    pinned_netloc = f"{pinned_host}:{port}"
-    pinned_url = parsed._replace(netloc=pinned_netloc).geturl()
-
-    request_headers = dict(headers or {})
-    request_headers.setdefault("Host", parsed.hostname)
-
-    request = httpx.Request(
-        method,
-        pinned_url,
-        data=data,
-        headers=request_headers,
-        extensions={"sni_hostname": parsed.hostname},
-    )
+    """Strict, public-only guarded request. Used by safe_get/safe_post."""
+    parsed, validated_ip = _validate_url(url, require_https=True, allow_private=False)
+    request = _build_pinned_request(method, parsed, validated_ip, data=data, headers=headers)
     with httpx.Client(timeout=timeout) as client:
         return client.send(request)
 
 
 def safe_get(url: str, *, headers: dict[str, str] | None = None, timeout: float = 10) -> httpx.Response:
-    """SSRF-guarded GET. Use for well-known/OIDC discovery documents."""
+    """SSRF-guarded GET, public addresses only. Use for well-known/OIDC discovery documents."""
     return _safe_request("GET", url, headers=headers, timeout=timeout)
 
 
@@ -111,5 +172,68 @@ def safe_post(
     headers: dict[str, str] | None = None,
     timeout: float = 10,
 ) -> httpx.Response:
-    """SSRF-guarded POST. Use for token endpoints discovered from a well-known document."""
+    """SSRF-guarded POST, public addresses only. Use for token endpoints discovered from a well-known document."""
     return _safe_request("POST", url, data=data, headers=headers, timeout=timeout)
+
+
+def _guarded_request(
+    method: str,
+    url: str,
+    *,
+    json: dict | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 10,
+    follow_redirects: bool = True,
+) -> httpx.Response:
+    """Permissive guarded request for MCP/A2A connection targets.
+
+    Allows private (RFC 1918/RFC 4193) addresses and both http/https, but
+    always blocks cloud metadata, loopback, link-local, multicast, reserved,
+    and unspecified addresses. Each redirect hop is independently validated
+    before being followed — the initial target passing validation does not
+    grant a later redirect target a pass.
+    """
+    current_url = url
+    with httpx.Client(timeout=timeout) as client:
+        for _ in range(_MAX_REDIRECTS + 1):
+            parsed, validated_ip = _validate_url(current_url, require_https=False, allow_private=True)
+            request = _build_pinned_request(
+                method, parsed, validated_ip,
+                json=json,
+                headers=headers,
+            )
+            resp = client.send(request)
+            if not follow_redirects or not resp.is_redirect:
+                return resp
+            location = resp.headers.get("location")
+            if not location:
+                return resp
+            current_url = str(httpx.URL(current_url).join(location))
+        raise SSRFBlockedError(f"Exceeded maximum redirect count ({_MAX_REDIRECTS}) fetching {url!r}")
+
+
+def guarded_get(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: float = 10,
+    follow_redirects: bool = True,
+) -> httpx.Response:
+    """SSRF-guarded GET for MCP/A2A connection targets (private addresses allowed).
+
+    Use for MCP server endpoint_url and A2A agent base_url calls — these
+    legitimately reach VPC-internal addresses, unlike OAuth infrastructure.
+    """
+    return _guarded_request("GET", url, headers=headers, timeout=timeout, follow_redirects=follow_redirects)
+
+
+def guarded_post(
+    url: str,
+    *,
+    json: dict | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 10,
+    follow_redirects: bool = True,
+) -> httpx.Response:
+    """SSRF-guarded POST for MCP/A2A connection targets (private addresses allowed)."""
+    return _guarded_request("POST", url, json=json, headers=headers, timeout=timeout, follow_redirects=follow_redirects)

--- a/backend/tests/test_a2a_connection_ssrf.py
+++ b/backend/tests/test_a2a_connection_ssrf.py
@@ -1,0 +1,116 @@
+"""Regression tests for the SSRF fix on A2A connection sinks in app.services.a2a.
+
+Follow-up finding to the SSRF/token-leak fix in test_mcp_ssrf.py: the same
+report flagged fetch_agent_card / _fetch_salesforce_agent_card, which built
+requests from agent.base_url (also user-supplied) and sent them via
+httpx.get with follow_redirects=True and no scheme/host validation — and
+echoed up to ~200 chars of the response body in error messages, making the
+SSRF non-blind. This also allowed a legitimate-looking initial base_url to
+redirect the request cross-host to a disallowed address.
+
+Unlike OAuth infrastructure, A2A agents are a legitimate use case for
+private/VPC-internal addresses, so guarded_get (net_guard's permissive
+guard level) is used here instead of safe_get — these tests confirm
+metadata/loopback/link-local targets are blocked (with no body echoed back)
+while private (VPC-internal) targets still work.
+
+These tests patch at the httpx.Client boundary (not app.services.a2a's
+guarded_get) so the real net_guard SSRF validation logic actually runs.
+"""
+import socket
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.services.a2a import _fetch_salesforce_agent_card, fetch_agent_card
+
+
+class TestFetchAgentCardSSRFGuard(unittest.TestCase):
+    def test_metadata_base_url_is_blocked(self) -> None:
+        with patch("httpx.Client") as mock_client_cls:
+            with self.assertRaises(ValueError) as ctx:
+                fetch_agent_card("http://169.254.169.254")
+        mock_client_cls.return_value.__enter__.return_value.send.assert_not_called()
+        self.assertIn("Blocked", str(ctx.exception))
+
+    def test_loopback_base_url_is_blocked(self) -> None:
+        with patch("httpx.Client") as mock_client_cls:
+            with self.assertRaises(ValueError):
+                fetch_agent_card("http://127.0.0.1:9011")
+        mock_client_cls.return_value.__enter__.return_value.send.assert_not_called()
+
+    def test_blocked_error_does_not_echo_response_body(self) -> None:
+        """The finding's non-blind concern: no attacker-controlled response
+        content should ever reach the raised error message for a blocked URL."""
+        with patch("httpx.Client"):
+            with self.assertRaises(ValueError) as ctx:
+                fetch_agent_card("http://169.254.169.254/leak-secret-data-here")
+        self.assertNotIn("leak-secret-data-here", str(ctx.exception))
+
+    def test_private_vpc_base_url_still_works(self) -> None:
+        """A2A agents on VPC-internal addresses must remain reachable — this
+        is a supported deployment pattern, unlike OAuth infrastructure."""
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("10.0.5.20", 8080))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_response = MagicMock(status_code=200, is_redirect=False)
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {
+                "name": "internal-agent",
+                "description": "desc",
+                "url": "http://10.0.5.20:8080",
+                "version": "1.0",
+            }
+            mock_client.send.return_value = mock_response
+
+            card = fetch_agent_card("http://10.0.5.20:8080")
+        self.assertEqual(card["name"], "internal-agent")
+
+    def test_redirect_to_metadata_is_blocked(self) -> None:
+        """A legitimate-looking initial base_url must not be able to redirect
+        the request cross-host to a disallowed address."""
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            def _resolve(hostname, *_args, **_kwargs):
+                if hostname == "agent.example.com":
+                    return [(socket.AF_INET, None, None, None, ("93.184.216.34", 80))]
+                if hostname == "169.254.169.254":
+                    return [(socket.AF_INET, None, None, None, ("169.254.169.254", 80))]
+                raise AssertionError(f"unexpected resolve for {hostname}")
+            mock_resolve.side_effect = _resolve
+
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            redirect_resp = MagicMock(status_code=302, is_redirect=True)
+            redirect_resp.headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+            mock_client.send.return_value = redirect_resp
+
+            with self.assertRaises(ValueError):
+                fetch_agent_card("http://agent.example.com")
+
+
+class TestSalesforceAgentCardSSRFGuard(unittest.TestCase):
+    def test_metadata_base_url_is_blocked(self) -> None:
+        with patch("httpx.Client") as mock_client_cls:
+            with self.assertRaises(ValueError):
+                _fetch_salesforce_agent_card("http://169.254.169.254", {})
+        mock_client_cls.return_value.__enter__.return_value.send.assert_not_called()
+
+    def test_private_vpc_base_url_still_works(self) -> None:
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("10.0.5.20", 8080))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_response = MagicMock(status_code=200, is_redirect=False)
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"name": "sf-agent"}
+            mock_client.send.return_value = mock_response
+
+            card = _fetch_salesforce_agent_card("http://10.0.5.20:8080", {})
+        self.assertEqual(card["name"], "sf-agent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_mcp_connection_ssrf.py
+++ b/backend/tests/test_mcp_connection_ssrf.py
@@ -1,0 +1,114 @@
+"""Regression tests for the SSRF fix on MCP connection sinks in app.services.mcp.
+
+Follow-up finding to the SSRF/token-leak fix in test_mcp_ssrf.py: that fix
+guarded the OAuth2 well-known/token-endpoint calls, but the primary
+connection sinks — server.endpoint_url, used by _call_streamable_http,
+_initialize_session, and _call_sse — went straight to httpx.post with no
+scheme/host validation at all. Unlike OAuth infrastructure, MCP servers are
+a legitimate use case for private/VPC-internal addresses (net_guard's
+guarded_get/guarded_post), so these tests confirm metadata/loopback/
+link-local targets are blocked while private (VPC-internal) targets still
+work.
+
+These tests patch at the httpx.Client boundary (not app.services.mcp's
+guarded_post) so the real net_guard SSRF validation logic actually runs —
+mocking guarded_post itself would bypass the code under test.
+"""
+import socket
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.services.mcp import _call_sse, _call_streamable_http, _initialize_session
+
+
+def _make_server(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        endpoint_url="http://169.254.169.254/mcp",
+        transport_type="streamable_http",
+        auth_type=None,
+        delegation_mode="m2m",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestStreamableHttpSSRFGuard(unittest.TestCase):
+    def test_metadata_endpoint_is_blocked(self) -> None:
+        server = _make_server(endpoint_url="http://169.254.169.254/mcp")
+        with patch("httpx.Client") as mock_client_cls:
+            result = _call_streamable_http(server, "tools/list")
+        self.assertIsNone(result)
+        mock_client_cls.return_value.__enter__.return_value.send.assert_not_called()
+
+    def test_loopback_endpoint_is_blocked(self) -> None:
+        server = _make_server(endpoint_url="http://127.0.0.1:9011/mcp")
+        with patch("httpx.Client") as mock_client_cls:
+            result = _call_streamable_http(server, "tools/list")
+        self.assertIsNone(result)
+        mock_client_cls.return_value.__enter__.return_value.send.assert_not_called()
+
+    def test_private_vpc_endpoint_still_works(self) -> None:
+        """MCP servers on VPC-internal addresses must remain reachable — this
+        is a supported deployment pattern, unlike OAuth infrastructure."""
+        server = _make_server(endpoint_url="http://10.0.5.20:8080/mcp")
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("10.0.5.20", 8080))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_response = MagicMock(status_code=200)
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.json.return_value = {"result": {"tools": []}}
+            mock_response.raise_for_status.return_value = None
+            mock_client.send.return_value = mock_response
+
+            result = _call_streamable_http(server, "tools/list")
+        self.assertIsNotNone(result)
+        self.assertTrue(mock_client.send.called)
+
+
+class TestInitializeSessionSSRFGuard(unittest.TestCase):
+    def test_metadata_endpoint_is_blocked(self) -> None:
+        server = _make_server(endpoint_url="http://169.254.169.254/mcp")
+        with patch("httpx.Client") as mock_client_cls:
+            session_id = _initialize_session(server, {})
+        self.assertIsNone(session_id)
+        mock_client_cls.return_value.__enter__.return_value.send.assert_not_called()
+
+
+class TestSSESSRFGuard(unittest.TestCase):
+    def test_metadata_endpoint_is_blocked(self) -> None:
+        server = _make_server(endpoint_url="http://169.254.169.254/mcp", transport_type="sse")
+        with patch("httpx.Client") as mock_client_cls:
+            result = _call_sse(server, "tools/list")
+        self.assertIsNone(result)
+        mock_client_cls.return_value.__enter__.return_value.send.assert_not_called()
+
+    def test_link_local_endpoint_is_blocked(self) -> None:
+        server = _make_server(endpoint_url="http://169.254.1.1/mcp", transport_type="sse")
+        with patch("httpx.Client") as mock_client_cls:
+            result = _call_sse(server, "tools/list")
+        self.assertIsNone(result)
+        mock_client_cls.return_value.__enter__.return_value.send.assert_not_called()
+
+    def test_private_vpc_endpoint_still_works(self) -> None:
+        server = _make_server(endpoint_url="http://10.0.5.20:8080/mcp", transport_type="sse")
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("10.0.5.20", 8080))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_response = MagicMock(status_code=200)
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.json.return_value = {"result": {}}
+            mock_response.raise_for_status.return_value = None
+            mock_client.send.return_value = mock_response
+
+            result = _call_sse(server, "tools/list")
+        self.assertIsNotNone(result)
+        self.assertTrue(mock_client.send.called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_net_guard.py
+++ b/backend/tests/test_net_guard.py
@@ -7,7 +7,15 @@ import socket
 import unittest
 from unittest.mock import patch, MagicMock
 
-from app.services.net_guard import SSRFBlockedError, _is_disallowed_ip, safe_get, safe_post
+from app.services.net_guard import (
+    SSRFBlockedError,
+    _is_always_disallowed_ip,
+    _is_disallowed_ip,
+    guarded_get,
+    guarded_post,
+    safe_get,
+    safe_post,
+)
 import ipaddress
 
 
@@ -91,6 +99,140 @@ class TestSafeGetPost(unittest.TestCase):
 
             sent_request = mock_client.send.call_args[0][0]
             self.assertIn("93.184.216.34", str(sent_request.url))
+            self.assertEqual(sent_request.method, "POST")
+
+
+class TestIsAlwaysDisallowedIp(unittest.TestCase):
+    """The permissive guard level: private/VPC addresses are allowed, but
+    metadata/loopback/link-local/multicast/reserved/unspecified never are."""
+
+    def test_private_ipv4_allowed(self) -> None:
+        self.assertFalse(_is_always_disallowed_ip(ipaddress.ip_address("10.0.0.5")))
+        self.assertFalse(_is_always_disallowed_ip(ipaddress.ip_address("192.168.1.1")))
+        self.assertFalse(_is_always_disallowed_ip(ipaddress.ip_address("172.16.0.1")))
+
+    def test_loopback_still_blocked(self) -> None:
+        self.assertTrue(_is_always_disallowed_ip(ipaddress.ip_address("127.0.0.1")))
+        self.assertTrue(_is_always_disallowed_ip(ipaddress.ip_address("::1")))
+
+    def test_metadata_and_link_local_still_blocked(self) -> None:
+        self.assertTrue(_is_always_disallowed_ip(ipaddress.ip_address("169.254.169.254")))
+        self.assertTrue(_is_always_disallowed_ip(ipaddress.ip_address("169.254.0.1")))
+
+    def test_public_ip_allowed(self) -> None:
+        self.assertFalse(_is_always_disallowed_ip(ipaddress.ip_address("93.184.216.34")))
+
+
+class TestGuardedGetPost(unittest.TestCase):
+    """guarded_get/guarded_post — used for MCP endpoint_url / A2A base_url,
+    where private/VPC-internal targets are a legitimate, supported use case."""
+
+    def test_allows_http_scheme(self) -> None:
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("93.184.216.34", 80))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.send.return_value = MagicMock(status_code=200, is_redirect=False)
+
+            resp = guarded_get("http://example.com/mcp")
+            self.assertEqual(resp.status_code, 200)
+
+    def test_allows_private_ip_target(self) -> None:
+        """VPC-internal MCP servers/A2A agents must remain reachable."""
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("10.0.5.20", 8080))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.send.return_value = MagicMock(status_code=200, is_redirect=False)
+
+            resp = guarded_get("http://internal-mcp.vpc.local:8080/mcp")
+            self.assertEqual(resp.status_code, 200)
+            sent_request = mock_client.send.call_args[0][0]
+            self.assertIn("10.0.5.20", str(sent_request.url))
+
+    def test_blocks_metadata_target(self) -> None:
+        with self.assertRaises(SSRFBlockedError):
+            guarded_get("http://169.254.169.254/latest/meta-data/")
+
+    def test_blocks_loopback_target(self) -> None:
+        with self.assertRaises(SSRFBlockedError):
+            guarded_get("http://127.0.0.1:9011/mcp")
+
+    def test_blocks_disallowed_scheme(self) -> None:
+        with self.assertRaises(SSRFBlockedError):
+            guarded_get("file:///etc/passwd")
+
+    def test_redirect_to_metadata_is_blocked(self) -> None:
+        """A legitimate-looking initial target must not be able to redirect
+        the request to a disallowed address (non-blind SSRF via redirect)."""
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            def _resolve(hostname, *_args, **_kwargs):
+                if hostname == "example.com":
+                    return [(socket.AF_INET, None, None, None, ("93.184.216.34", 80))]
+                if hostname == "169.254.169.254":
+                    return [(socket.AF_INET, None, None, None, ("169.254.169.254", 80))]
+                raise AssertionError(f"unexpected resolve for {hostname}")
+            mock_resolve.side_effect = _resolve
+
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            redirect_resp = MagicMock(status_code=302, is_redirect=True)
+            redirect_resp.headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+            mock_client.send.return_value = redirect_resp
+
+            with self.assertRaises(SSRFBlockedError):
+                guarded_get("http://example.com/mcp")
+
+    def test_redirect_to_allowed_private_target_is_followed(self) -> None:
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            def _resolve(hostname, *_args, **_kwargs):
+                if hostname == "gateway.internal":
+                    return [(socket.AF_INET, None, None, None, ("10.0.0.9", 80))]
+                if hostname == "backend.internal":
+                    return [(socket.AF_INET, None, None, None, ("10.0.0.10", 80))]
+                raise AssertionError(f"unexpected resolve for {hostname}")
+            mock_resolve.side_effect = _resolve
+
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            redirect_resp = MagicMock(status_code=302, is_redirect=True)
+            redirect_resp.headers = {"location": "http://backend.internal/mcp"}
+            final_resp = MagicMock(status_code=200, is_redirect=False)
+            mock_client.send.side_effect = [redirect_resp, final_resp]
+
+            resp = guarded_get("http://gateway.internal/mcp")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(mock_client.send.call_count, 2)
+
+    def test_exceeds_max_redirects_raises(self) -> None:
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("93.184.216.34", 80))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            redirect_resp = MagicMock(status_code=302, is_redirect=True)
+            redirect_resp.headers = {"location": "http://example.com/next"}
+            mock_client.send.return_value = redirect_resp
+
+            with self.assertRaises(SSRFBlockedError):
+                guarded_get("http://example.com/mcp")
+
+    def test_guarded_post_sends_json_to_pinned_ip(self) -> None:
+        with patch("socket.getaddrinfo") as mock_resolve, \
+             patch("httpx.Client") as mock_client_cls:
+            mock_resolve.return_value = [(socket.AF_INET, None, None, None, ("10.0.0.5", 80))]
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.send.return_value = MagicMock(status_code=200, is_redirect=False)
+
+            guarded_post("http://internal-mcp.vpc.local/mcp", json={"jsonrpc": "2.0", "method": "initialize"})
+
+            sent_request = mock_client.send.call_args[0][0]
+            self.assertIn("10.0.0.5", str(sent_request.url))
             self.assertEqual(sent_request.method, "POST")
 
 


### PR DESCRIPTION
## Summary
Follow-up to PR #12 (fail-closed auth + OAuth well-known SSRF guard), flagged by the same researcher: PR #12 routed the OAuth2 discovery/token fetches through `net_guard`, but the primary connection sinks were not — `server.endpoint_url` in `mcp.py` (`_call_streamable_http`, `_initialize_session`, `_call_sse`) and the `base_url`-derived URL in `a2a.py` (`fetch_agent_card`, `_fetch_salesforce_agent_card`) went straight to `httpx` with no scheme/host validation. The A2A path also echoed up to ~200 chars of the response body in error messages and followed cross-host redirects unconditionally (`follow_redirects=True`), making the SSRF non-blind.

- Unlike the OAuth well-known/token endpoints `net_guard` already protects (always public-facing identity providers), MCP servers and A2A agents are a legitimate use case for private/VPC-internal addresses — the backend runs in private subnets specifically to support this.
- Adds a second, permissive guard level to `net_guard.py` (`guarded_get`/`guarded_post`): allows `http`/`https` and private (RFC 1918/RFC 4193) addresses, but always blocks cloud metadata, loopback, link-local, multicast, reserved, and unspecified addresses, and re-validates every redirect hop before following it (up to 5 hops).
- Wires this into all four connection sinks and removes the raw response-body echo from A2A error messages.
- Documents the two guard levels (`safe_get`/`safe_post` vs `guarded_get`/`guarded_post`) in `backend/SPECIFICATIONS.md`.

## Test Plan
- 20 new regression tests (`test_net_guard.py`, `test_mcp_connection_ssrf.py`, `test_a2a_connection_ssrf.py`) covering:
  - Metadata/loopback/link-local targets blocked at each connection sink
  - Private/VPC-internal targets still reachable (regression guard against breaking the supported use case)
  - Cross-host redirect-to-metadata blocked
  - Blocked-URL errors never echo the disallowed target's response body
- Full backend suite: 683 passed, only 3 known pre-existing failures unrelated to this change (confirmed identical on `main`)